### PR TITLE
Fix permission errors when running playbook as non-root user

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,5 +7,6 @@ steps:
 - name: Build
   image: geerlingguy/docker-ubuntu1804-ansible:testing
   commands:
+  - ansible-lint -x ANSIBLE0013,ANSIBLE0016 play_webserver.yml
   - ansible-galaxy install -r ./requirements.yml
   - ansible-playbook play_webserver.yml -i inv_localhost

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Drupal 8 stack running on Apache with MySQL.
 
 # Run
 
+Change `drupal_core_owner` in `/vars/play_webserver.yml` to a user on the your system that is a sudoer.
+
 ```bash
 # Setup your system
 ansible-galaxy install -r ./requirements.yml

--- a/play_webserver.yml
+++ b/play_webserver.yml
@@ -1,22 +1,6 @@
 ---
 
 - hosts: webserver
-  vars_files:
-    - vars/play_webserver.yml
-
-  tasks:
-  - name: Add drupal group
-    group:
-      name: drupal
-      state: present
-
-  - name: Add drupal core owner
-    user:
-      name: "{{drupal_core_owner}}"
-      comment: Drupal core owner
-      group: drupal
-
-- hosts: webserver
   become: yes
   vars_files:
     - vars/play_webserver.yml
@@ -36,4 +20,5 @@
 
   tasks:
   - name: Fix permissions
+    become: yes
     script: files/fixperms.sh --drupal_path="{{ drupal_core_path }}" --drupal_user="{{ drupal_core_owner }}"

--- a/vars/play_webserver.yml
+++ b/vars/play_webserver.yml
@@ -6,7 +6,7 @@ drupal_site_name: "Drupal Test"
 drupal_account_name: admin
 drupal_account_pass: admin
 drupal_deploy_dir: "/var/www/drupal"
-drupal_core_owner: drupal
+drupal_core_owner: root
 drupal_core_owner_become: true
 drupal_core_path: "{{ drupal_deploy_dir }}/web"
 


### PR DESCRIPTION
Bug was caused by only testing playbook in a Docker container, where I was running as root.  

Fixes #1 